### PR TITLE
Enable S3-SQLMesh Integration

### DIFF
--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -3,6 +3,8 @@ gateways:
     connection:
       type: duckdb
       database: osaa_mvp.db
+      # Configure DuckDB with httpfs extension for S3 access
+      extensions: ['httpfs']
 
 default_gateway: local
 

--- a/sqlMesh/macros/s3_paths.py
+++ b/sqlMesh/macros/s3_paths.py
@@ -1,0 +1,51 @@
+import os
+from sqlmesh import macro
+from sqlglot import exp
+
+def parse_fully_qualified_name(fqtn):
+    """Parse a fully qualified table name into its components."""
+    # Convert SQLGlot expression to string
+    if isinstance(fqtn, exp.Expression):
+        if isinstance(fqtn, exp.Identifier):
+            fqtn = fqtn.name
+        else:
+            fqtn = str(fqtn)
+    
+    parts = fqtn.split('.')
+    if len(parts) != 3:
+        raise ValueError("Fully qualified table name must be in the format 'database.schema.table'")
+    database, schema, table = parts
+    return database, schema, table
+
+@macro()
+def s3_landing_path(evaluator, subfolder_filename):
+    """Construct S3 landing path."""
+    bucket = os.environ.get('S3_BUCKET_NAME', 'osaa-mvp')
+    target = os.environ.get('TARGET', 'prod')
+    username = os.environ.get('USERNAME', 'default')
+
+    # Construct the environment path segment
+    env_path = target if target in ['prod', 'int'] else f"{target}_{username}"
+    
+    # Convert input to string if it's a SQLGlot expression
+    if isinstance(subfolder_filename, exp.Expression):
+        subfolder_filename = str(subfolder_filename).strip("'")
+    
+    path = f"s3://{bucket}/{env_path}/landing/{subfolder_filename}.parquet"
+    return exp.Literal.string(path)
+
+@macro()
+def s3_transformed_path(evaluator, fqtn):
+    """Construct S3 transformed path."""
+    bucket = os.environ.get('S3_BUCKET_NAME', 'osaa-mvp')
+    target = os.environ.get('TARGET', 'dev')
+    username = os.environ.get('USERNAME', 'default')
+
+    # Construct the environment path segment
+    env_path = target if target in ['prod', 'int'] else f"{target}_{username}"
+    
+    
+    _, schema, table = parse_fully_qualified_name(fqtn)
+    table = table.strip("'")
+    path = f"s3://{bucket}/{env_path}/transformed/{schema}/{table}"
+    return exp.Literal.string(path)

--- a/sqlMesh/models/intermediate/wdi_country_averages.sql
+++ b/sqlMesh/models/intermediate/wdi_country_averages.sql
@@ -1,0 +1,39 @@
+MODEL (
+    name intermediate.wdi_country_averages,
+    kind FULL
+);
+
+WITH source_data AS (
+    SELECT *
+    FROM intermediate.wdi
+),
+
+country_averages AS (
+    SELECT 
+        country_id,
+        AVG(CAST(value AS FLOAT)) as avg_value_by_country
+    FROM source_data
+    WHERE value IS NOT NULL 
+      AND value != ''
+      AND TRY_CAST(value AS FLOAT) IS NOT NULL
+    GROUP BY country_id
+),
+
+final AS (
+    SELECT 
+        s.*,
+        ca.avg_value_by_country
+    FROM source_data s
+    LEFT JOIN country_averages ca ON s.country_id = ca.country_id
+)
+
+SELECT * FROM final
+;
+
+@IF(
+  @runtime_stage = 'evaluating',
+    COPY (SELECT * FROM intermediate.wdi_country_averages)
+    TO @s3_transformed_path('osaa_mvp.intermediate.wdi_country_averages')
+    (FORMAT PARQUET)
+)
+;

--- a/sqlMesh/models/sources/opri/data_national.sql
+++ b/sqlMesh/models/sources/opri/data_national.sql
@@ -7,5 +7,7 @@ MODEL (
   SELECT
     *
   FROM
-    source.OPRI_DATA_NATIONAL
-  
+
+    read_parquet(
+        @s3_landing_path('edu/OPRI_DATA_NATIONAL')
+    )

--- a/sqlMesh/models/sources/opri/label.sql
+++ b/sqlMesh/models/sources/opri/label.sql
@@ -7,5 +7,6 @@ MODEL (
   SELECT
     *
   FROM
-    source.OPRI_LABEL
-  
+    read_parquet(
+        @s3_landing_path('edu/OPRI_LABEL')
+    )

--- a/sqlMesh/models/sources/sdg/data_national.sql
+++ b/sqlMesh/models/sources/sdg/data_national.sql
@@ -7,5 +7,6 @@ MODEL (
   SELECT
     *
   FROM
-    source.SDG_DATA_NATIONAL
-  
+    read_parquet(
+        @s3_landing_path('edu/SDG_DATA_NATIONAL')
+    )

--- a/sqlMesh/models/sources/sdg/label.sql
+++ b/sqlMesh/models/sources/sdg/label.sql
@@ -7,4 +7,6 @@ MODEL (
   SELECT
     *
   FROM
-    source.SDG_LABEL
+    read_parquet(
+        @s3_landing_path('edu/SDG_LABEL')
+    )

--- a/sqlMesh/models/sources/wdi/csv.sql
+++ b/sqlMesh/models/sources/wdi/csv.sql
@@ -6,5 +6,6 @@ MODEL (
   SELECT
     *
   FROM
-    source.WDICSV
-  
+      read_parquet(
+        @s3_landing_path('wdi/WDICSV')
+    )

--- a/sqlMesh/models/sources/wdi/series.sql
+++ b/sqlMesh/models/sources/wdi/series.sql
@@ -6,4 +6,6 @@ MODEL (
   SELECT
     *
   FROM
-    source.WDISeries
+    read_parquet(
+        @s3_landing_path('wdi/WDISeries')
+    )

--- a/src/pipeline/upload/run.py
+++ b/src/pipeline/upload/run.py
@@ -42,7 +42,10 @@ class Upload:
         Upload a Duckdb table to s3, given the schema and table name and path.
         """    
         # Format the fully qualified table name with environment
-        fully_qualified_name = f"{schema_name}__{self.env}.{table_name}"
+        if self.env == 'prod':
+            fully_qualified_name = f"{schema_name}.{table_name}"
+        else:
+            fully_qualified_name = f"{schema_name}__{self.env}.{table_name}"
         
         self.con.sql(f"""
             COPY (SELECT * FROM {fully_qualified_name})


### PR DESCRIPTION
This PR includes changes to enable S3 integration and improve data handling with DuckDB:
- Added the httpfs extension to support S3 reading and writing from withing SQLMesh.
- Created helper macros, such as @s3_landing_path, to construct environment-specific S3 paths dynamically.
- Replaced direct references to data sources with read_parquet functions for reading parquet files from S3 paths.
- Created a new model to demonstrate how the upload step can be integrated into SQLMesh execution, replacing the limited and hardcoded upload logic currently handled outside SQLMesh
