### PR TITLE
specify data types to avoid type issues downstream

### DIFF
--- a/sqlMesh/models/sources/opri/label.sql
+++ b/sqlMesh/models/sources/opri/label.sql
@@ -1,7 +1,11 @@
 MODEL (
     name opri.label,
     kind FULL,
-    cron '@daily'
+    cron '@daily',
+    columns (
+      INDICATOR_ID TEXT,
+      INDICATOR_LABEL_EN TEXT
+    )
   );
 
   SELECT

--- a/sqlMesh/models/sources/sdg/label.sql
+++ b/sqlMesh/models/sources/sdg/label.sql
@@ -1,7 +1,11 @@
 MODEL (
     name sdg.label,
     kind FULL,
-    cron '@daily'
+    cron '@daily',
+    columns (
+      INDICATOR_ID TEXT,
+      INDICATOR_LABEL_EN TEXT
+    )
   );
 
   SELECT


### PR DESCRIPTION
After specifying column data types, [this issue](https://github.com/UN-OSAA/osaa-mvp/issues/12) went away and successfully ran `docker compose run --rm pipeline etl`