### PR TITLE
Bug/test just commands

### DIFF
--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -5,14 +5,6 @@ gateways:
       database: osaa_mvp.db
       # Configure DuckDB with httpfs extension for S3 access
       extensions: ['httpfs']
-    # state_connection:
-    #   type: postgres
-    #   host: ep-still-firefly-a5jpi497.us-east-2.aws.neon.tech
-    #   port: 5432
-    #   user: some_db_owner
-    #   password: {{ env_var ('POSTGRES_NEON_PASSWORD') }}
-    #   database: sqlmesh_state
-    #   pre_ping: True
 
 default_gateway: local
 

--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -5,6 +5,14 @@ gateways:
       database: osaa_mvp.db
       # Configure DuckDB with httpfs extension for S3 access
       extensions: ['httpfs']
+    # state_connection:
+    #   type: postgres
+    #   host: ep-still-firefly-a5jpi497.us-east-2.aws.neon.tech
+    #   port: 5432
+    #   user: some_db_owner
+    #   password: {{ env_var ('POSTGRES_NEON_PASSWORD') }}
+    #   database: sqlmesh_state
+    #   pre_ping: True
 
 default_gateway: local
 

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -9,7 +9,7 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
     # RAW_DATA_DIR = os.path.join(ROOT_DIR, 'raw_data')
     # PROC_DATA_DIR = os.path.join(ROOT_DIR, 'processed')
 
-DATALAKE_DIR = os.path.join(ROOT_DIR, 'datalake')
+DATALAKE_DIR = os.path.join(ROOT_DIR, 'data')
 RAW_DATA_DIR = os.getenv('RAW_DATA_DIR', os.path.join(DATALAKE_DIR, 'raw'))
 STAGING_DATA_DIR = os.path.join(DATALAKE_DIR, 'staging')
 MASTER_DATA_DIR = os.path.join(STAGING_DATA_DIR, 'master')


### PR DESCRIPTION
The file directory path for sample data was wrong and needed to be fixed for `just ingest` to run correctly. Without this change, the command runs successfully without any processed data ([related to this another issue mentioned by @shuaahvee](https://github.com/UN-OSAA/osaa-mvp/issues/8)).  