### PR TITLE
add sample description

### DIFF
--- a/sqlMesh/models/intermediate/sdg.sql
+++ b/sqlMesh/models/intermediate/sdg.sql
@@ -1,6 +1,27 @@
 MODEL (
   name intermediate.sdg,
-  kind FULL
+  kind FULL,
+  description 'This model contains Sustainable Development Goals (SDG) data for all countries and indicators.
+  Publishing Org: UN
+  Link to raw data: https://unstats.un.org/sdgs/dataportal
+  Dataset owner:
+    Name: UN
+    Contact info: https://unstats.un.org/sdgs/contact-us/
+  Funding Source: 
+  Maintenance Status: Actively Maintained
+  How data was collected: https://unstats.un.org/sdgs/dataContacts/
+  Update Cadence: Annually
+  Transformations of raw data (column renaming, type casting, etc): indicator labels and descriptions are joined together
+  Column descriptions:
+    indicator_id: The unique identifier for the indicator
+    country_id: The unique identifier for the country
+    year: The year of the data
+    value: The value of the indicator for the country and year
+    magnitude: The magnitude of the indicator for the country and year
+    qualifier: The qualifier of the indicator for the country and year
+    indicator_description: The description of the indicator
+  Primary Key: indicator_id, country_id, year
+    '
 );
 
 SELECT


### PR DESCRIPTION
This PR adds a sample description with fields from the [data cards framework](https://sites.research.google/datacardsplaybook/). 

Some notes:

- unlike dbt, model/ comment descriptions can't be stored in yaml files and referenced in models. instead they need to be in the model's .sql or .py model directly. There are a few approaches to documenting models and columns: [model comments](https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview/#model-comment), [columns descriptions](https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview/#explicit-column-comments), [python model column_descriptions](https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview/#python-models), or [tags](https://sqlmesh.readthedocs.io/en/stable/concepts/models/overview/#tags). I think the since a lot of the data cards framework metadata is tied to a model/ dataset and not to individual columns, I opted to shoehorn all the info into the model description. In the future we may want to create a script that allows us to inject and reuse definitions or form some kind of lineage
- The data cards framework has a lotttt of potential metadata fields. I included the ones that seemed most relevant but this PR shouldnt be taken as a final opinion on what we should use, just a starting off point
- Since sqlmesh attempts to store model descriptions in the database it's running on, I don't know if this approach will work with our current process of writing to parquet since afaik parquet doesnt support this kind of description metadata