### PR TITLE
Feat/Add SQLMesh UI Support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ POSTGRES_PASSWORD=your_pass
 POSTGRES_DATABASE=your_database
 # Specify Gateway
 GATEWAY=your_gateway
+
+UI_PORT=8080

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __MACOSX
 sqlMesh/.cache/*
 sqlMesh/logs
 sqlMesh/*.db
+sqlMesh/*.db.wal
 
 *.pyc
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ docker compose up
 ```
 By default, the container will run the entire elt process `just elt`.
 
+To run the SQLMesh UI:
+```bash
+docker compose --profile ui up ui
+```
+Note: The UI must be run using the profile flag as shown above.
+
 ###### One-off Pipeline Components
 You can run specific parts of the pipeline:
 1. Run only the ingestion process:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,35 @@
 name: osaa-mvp
+
+x-common-config: &common-config
+  build: .
+  env_file: .env
+  volumes:
+    - ./datalake:/app/datalake
+    - ./sqlMesh:/app/sqlMesh
+  environment:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+    - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+    - TARGET=${TARGET}
+    - USERNAME=${USERNAME}
+    - DB_PATH=/app/sqlMesh/osaa_mvp.db
+
 services:
   pipeline:
-    build: .
+    <<: *common-config
     container_name: osaa-mvp-main
-    env_file: .env
-    volumes:
-      - ./datalake:/app/datalake
-      - ./sqlMesh:/app/sqlMesh
     environment:
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
-      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
-      - TARGET=${TARGET}
-      - USERNAME=${USERNAME}
-      - DB_PATH=/app/sqlMesh/osaa_mvp.db
-    command: etl
+      - GATEWAY=${GATEWAY:-local}
+    profiles:
+      - default
+
+  ui:
+    <<: *common-config
+    container_name: osaa-mvp-ui
+    entrypoint: ["sqlmesh"]
+    command: ["ui", "--port", "${UI_PORT:-8000}"]
+    ports:
+      - "${UI_PORT:-8000}:${UI_PORT:-8000}"
+    profiles:
+      - ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,12 @@ services:
   ui:
     <<: *common-config
     container_name: osaa-mvp-ui
+    working_dir: /app/sqlMesh
     entrypoint: ["sqlmesh"]
-    command: ["ui", "--port", "${UI_PORT:-8000}"]
+    command: ["ui", "--host", "0.0.0.0", "--port", "${UI_PORT:-8080}"]
+    environment:
+      - GATEWAY=local
     ports:
-      - "${UI_PORT:-8000}:${UI_PORT:-8000}"
+      - "${UI_PORT:-8080}:${UI_PORT:-8080}"
     profiles:
       - ui

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,10 @@ case "$1" in
     sqlmesh --gateway "${GATEWAY:-local}" plan --auto-apply --include-unmodified --create-from prod --no-prompts "${TARGET:-dev}"
     echo "End sqlMesh"
     ;;
+  "ui")
+    cd sqlMesh
+    sqlmesh ui --port "${UI_PORT:-8000}"
+    ;;
   "upload")
     python -m pipeline.upload.run
     ;;
@@ -53,6 +57,7 @@ case "$1" in
     echo "  transform    - Run SQLMesh transformations"
     echo "  upload       - Run the data upload process"
     echo "  etl          - Run the complete pipeline (ingest + transform + upload)"
+    echo "  ui           - Start the SQLMesh UI server"
     echo "  config_test  - Test and display current configuration settings"
     echo
     echo "Usage: docker compose run pipeline <command>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ duckdb==1.1.3
 fsspec>=2024.2.0
 ibis-framework[duckdb]==9.5.0
 mypy==1.8.0
+numpy<2.0.0
+sqlfluff==3.0.0
+sqlglot~=25.20.2
+sqlmesh[web,ibis]==0.122.3
 
 # Type Checking
 mypy-extensions==1.0.0
@@ -34,9 +38,6 @@ psycopg2-binary==2.9.9
 
 # Safety Dependency Checking
 safety==3.0.1
-sqlfluff==3.0.0
-sqlglot~=25.20.2
-sqlmesh==0.122.3
 types-freezegun
 types-python-dateutil
 types-PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ duckdb==1.1.3
 fsspec>=2024.2.0
 ibis-framework[duckdb]==9.5.0
 mypy==1.8.0
-numpy<2.0.0
 sqlfluff==3.0.0
 sqlglot~=25.20.2
 sqlmesh[web,ibis]==0.122.3


### PR DESCRIPTION
This PR adds support for SQLMesh's web UI interface

## Key Changes
- Added UI service to docker-compose.yml using common configuration
- Updated entrypoint.sh to handle UI command
- Added web dependencies to requirements.txt
- Added UI_PORT configuration to .env.example

## Important Caveat
The UI service must be run using the dedicated profile flag:
```bash
docker compose --profile ui up ui
```
Do NOT use `docker compose run pipeline ui` as it won't work with the `--gateway` flag. The UI command has different CLI options than other SQLMesh commands.

## Testing
1. Copy UI_PORT to your .env file
2. Run `docker compose --profile ui up ui`
3. Access UI at http://localhost:8000 (or your configured port)