### PR TITLE
fix(sqlmesh): convert postgres port to integer in config

### DIFF
--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -14,7 +14,7 @@ gateways:
     state_connection:
       type: postgres
       host: {{ env_var ('POSTGRES_HOST') }}
-      port: {{ env_var ('POSTGRES_PORT') }}
+      port: {{ env_var ('POSTGRES_PORT')|int }}
       user: {{ env_var ('POSTGRES_USER') }}
       password: {{ env_var ('POSTGRES_PASSWORD') }}
       database: {{ env_var ('POSTGRES_DATABASE') }}


### PR DESCRIPTION
When using the local gateway, SQLMesh still validates the shared_state gateway's postgres configuration. While most missing postgres environment variables are somehow accepted, the port specifically fails validation due to type mismatch. This PR adds type casting to fix the port validation error, though the underlying behavior of validating unused gateway configurations remains.

## Changes
- Added Jinja2 `|int` filter to properly convert postgres port to integer
- Ensures proper type validation for postgres configuration

## Testing
Tested with:
- `GATEWAY=local` without postgres configuration
- `GATEWAY=shared_state` with proper postgres configuration

Fixes #34 

## Notes
This change ensures that:
1. When using `GATEWAY=local`, postgres configuration is not required
2. When using `GATEWAY=shared_state`, proper postgres configuration is validated