### PR TITLE
Update the script to find Master folder for uploads

### DIFF
--- a/src/pipeline/upload/run.py
+++ b/src/pipeline/upload/run.py
@@ -77,7 +77,7 @@ class Upload:
             schemas_query = """
             SELECT DISTINCT schema_name
             FROM information_schema.schemata
-            WHERE LOWER(schema_name) LIKE 'master_%'
+            WHERE LOWER(schema_name) LIKE 'master%'
             """
             schemas = self.con.execute(schemas_query).fetchall()
             logger.info(f"Found {len(schemas)} schemas:")

--- a/src/pipeline/upload/run.py
+++ b/src/pipeline/upload/run.py
@@ -77,12 +77,10 @@ class Upload:
             schemas_query = """
             SELECT DISTINCT schema_name
             FROM information_schema.schemata
-            WHERE schema_name LIKE '%__dev' 
-               OR schema_name LIKE '%__prod'
-               OR (schema_name IN ('sdg', 'wdi', 'opri', 'master') AND '{}' = 'prod')
-            """.format(self.env)
+            WHERE LOWER(schema_name) LIKE 'master_%'
+            """
             schemas = self.con.execute(schemas_query).fetchall()
-            logger.info(f"Found {len(schemas)} SQLMesh schemas:")
+            logger.info(f"Found {len(schemas)} schemas:")
             for (schema,) in schemas:
                 logger.info(f"   • Found schema: {schema}")
 

--- a/src/pipeline/upload/run.py
+++ b/src/pipeline/upload/run.py
@@ -77,8 +77,10 @@ class Upload:
             schemas_query = """
             SELECT DISTINCT schema_name
             FROM information_schema.schemata
-            WHERE schema_name LIKE '%__dev' OR schema_name LIKE '%__prod'
-            """
+            WHERE schema_name LIKE '%__dev' 
+               OR schema_name LIKE '%__prod'
+               OR (schema_name IN ('sdg', 'wdi', 'opri', 'master') AND '{}' = 'prod')
+            """.format(self.env)
             schemas = self.con.execute(schemas_query).fetchall()
             logger.info(f"Found {len(schemas)} SQLMesh schemas:")
             for (schema,) in schemas:


### PR DESCRIPTION
In the upload process, we run a query in DuckDB to get the list of schemas built by sqlmesh. Running in dev vs prod environments results in different schema names, and also each dataset gets its own schema.

To keep this straightforward, I suggest we change this to only upload the final "indicators.parquet" file, which will work in all 3 environments