### PR TITLE
Upgrade Core Dependencies to Enable SQLMesh Post-Statements

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 # Create necessary directories
 RUN mkdir -p datalake/raw sqlMesh
 
+# Install git for GitHub dependencies
+RUN apt-get update && \
+    apt-get install -y git && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
 COPY requirements.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ boto3>=1.35.0
 colorlog==6.8.0
 duckdb==1.1.3
 fsspec>=2024.2.0
-ibis-framework[duckdb]==9.5.0
+git+https://github.com/ibis-project/ibis.git@bd30ba5#egg=ibis-framework[duckdb]
 mypy==1.8.0
 sqlfluff==3.0.0
-sqlglot~=25.20.2
-sqlmesh[web,ibis]==0.122.3
+sqlglot==26.2.1
+sqlmesh[web,ibis]==0.146.0
 
 # Type Checking
 mypy-extensions==1.0.0
@@ -36,7 +36,7 @@ s3fs>=2024.2.0
 psycopg2-binary==2.9.9
 
 # Safety Dependency Checking
-safety==3.0.1
+safety==3.2.14
 types-freezegun
 types-python-dateutil
 types-PyYAML


### PR DESCRIPTION
## Context
We need to upgrade SQLMesh to support post-statement macros for Python models, which will allow us to:
- Integrate the upload process directly into SQLMesh models
- Remove the separate upload step

## Changes
- Upgraded `sqlmesh` from 0.122.3 to 0.146.0 to support post-statement macros
- Upgraded `sqlglot` from 25.20.2 to 26.2.1 to meet new SQLMesh requirements
- Switched `ibis-framework` to GitHub main branch (commit bd30ba5) to resolve dependency conflicts
- Updated `safety` package from 3.0.1 to 3.2.14 to resolve dependency conflicts

## Testing
`docker compose run --rm pipeline etl` completes successfully

## Additional Changes
- Added git installation to Dockerfile to support installing ibis-framework from GitHub
- This ensures CI pipeline can build the container successfully when using GitHub-hosted dependencies