### PR TITLE
metadata tracking

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ case "$1" in
     ;;
   "ui")
     cd sqlMesh
-    uv run sqlmeshui --port "${UI_PORT:-8080}"
+    uv run sqlmesh ui --port "${UI_PORT:-8080}"
     ;;
   "etl")
     echo "Starting pipeline"

--- a/sqlMesh/models/sources/sdg/sdg_indicators.py
+++ b/sqlMesh/models/sources/sdg/sdg_indicators.py
@@ -34,8 +34,8 @@ COLUMN_SCHEMA = {
         "indicator_description": "The description of the indicator",
     },
     grain=("indicator_id", "country_id", "year"),
-    virtual_properties={
-        "publishing org": "UN",
+    physical_properties={
+        "publishing_org": "UN",
         "link_to_raw_data": "https://unstats.un.org/sdgs/dataportal",
         "dataset_owner": "UN",
         "dataset_owner_contact_info": "https://unstats.un.org/sdgs/contact-us/",

--- a/sqlMesh/models/sources/sdg/sdg_indicators.py
+++ b/sqlMesh/models/sources/sdg/sdg_indicators.py
@@ -23,28 +23,28 @@ COLUMN_SCHEMA = {
     kind="FULL",
     columns=COLUMN_SCHEMA,
     post_statements=["@s3_write()"],
-    description="""
-    This model contains Sustainable Development Goals (SDG) data for all countries and indicators.
-    Publishing Org: UN
-    Link to raw data: https://unstats.un.org/sdgs/dataportal
-    Dataset owner:
-        Name: UN
-        Contact info: https://unstats.un.org/sdgs/contact-us/
-    Funding Source: 
-    Maintenance Status: Actively Maintained
-    How data was collected: https://unstats.un.org/sdgs/dataContacts/
-    Update Cadence: Annually
-    Transformations of raw data (column renaming, type casting, etc): indicator labels and descriptions are joined together
-    Column descriptions:
-        indicator_id: The unique identifier for the indicator
-        country_id: The unique identifier for the country
-        year: The year of the data
-        value: The value of the indicator for the country and year
-        magnitude: The magnitude of the indicator for the country and year
-        qualifier: The qualifier of the indicator for the country and year
-        indicator_description: The description of the indicator
-    Primary Key: indicator_id, country_id, year
-    """,
+    description="""This model contains Sustainable Development Goals (SDG) data for all countries and indicators.""",
+    column_descriptions={
+        "indicator_id": "The unique identifier for the indicator",
+        "country_id": "The unique identifier for the country",
+        "year": "The year of the data",
+        "value": "The value of the indicator for the country and year",
+        "magnitude": "The magnitude of the indicator for the country and year",
+        "qualifier": "The qualifier of the indicator for the country and year",
+        "indicator_description": "The description of the indicator",
+    },
+    grain=("indicator_id", "country_id", "year"),
+    virtual_properties={
+        "publishing org": "UN",
+        "link_to_raw_data": "https://unstats.un.org/sdgs/dataportal",
+        "dataset_owner": "UN",
+        "dataset_owner_contact_info": "https://unstats.un.org/sdgs/contact-us/",
+        "funding_source": "UN",
+        "maintenance_status": "Actively Maintained",
+        "how_data_was_collected": "https://unstats.un.org/sdgs/dataContacts/",
+        "update_cadence": "Annually",
+        "transformations_of_raw_data": "indicator labels and descriptions are joined together",
+    },
 )
 def entrypoint(evaluator: MacroEvaluator) -> str:
     source_folder_path = "sdg"


### PR DESCRIPTION
## Changes
- Added `physical_properties` that holds arbitrary metadata about a model
- Unrelated change: fixed a typo in a cli command for sqlmesh ui

## FYI: how to get model properties from the state schema/db:
```
-- a duckdb query to get model properties of the latest snapshot of a model 
SELECT
    json_extract(snapshot, '$.node.name') AS model_name,
    json_extract(snapshot, '$.node.description') AS model_description,
    json_extract(snapshot, '$.node.kind') AS model_kind,
    json_extract(snapshot, '$.node.grains') AS grain,
    json_extract(snapshot, '$.node.columns') AS columns,
    json_extract(snapshot, '$.node.column_descriptions') AS column_descriptions,
    json_extract(snapshot, '$.node.physical_properties') AS physical_properties
FROM sqlmesh._snapshots
WHERE updated_ts = (SELECT MAX(updated_ts) FROM sqlmesh._snapshots)
AND name = '"osaa_mvp"."sources"."sdg"'  -- your model name here
;
```