### PR TITLE
 Implement State Sharing with duckdb+S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,6 @@ TARGET=dev
 USERNAME=your_username
 
 # SQLMesh Configuration
-# Postgres for the shared state db
-POSTGRES_HOST=your_host
-POSTGRES_PORT=your_port
-POSTGRES_USER=your_user
-POSTGRES_PASSWORD=your_pass
-POSTGRES_DATABASE=your_database
-# Specify Gateway
 GATEWAY=local
 
 UI_PORT=8080

--- a/.github/workflows/daily_transform.yml
+++ b/.github/workflows/daily_transform.yml
@@ -10,11 +10,6 @@ jobs:
   etl:
     runs-on: ubuntu-latest
     env:
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
-      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT || '5432' }}
-      POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB || 'postgres' }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,9 +38,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
-          POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB || 'postgres' }}
           USERNAME: ${{ secrets.USERNAME || 'osaa-mvp-user' }}
-          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT || '5432' }}
         run: |
           docker run --rm \
             -e TARGET=$TARGET \
@@ -56,10 +49,5 @@ jobs:
             -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
             -e S3_BUCKET_NAME=$S3_BUCKET_NAME \
             -e USERNAME=$USERNAME \
-            -e POSTGRES_HOST=$POSTGRES_HOST \
-            -e POSTGRES_PORT=$POSTGRES_PORT \
-            -e POSTGRES_USER=$POSTGRES_USER \
-            -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-            -e POSTGRES_DATABASE=$POSTGRES_DATABASE \
             ghcr.io/un-osaa/osaa-mvp:latest \
             etl prod 

--- a/.github/workflows/deploy_to_ghcr.yml
+++ b/.github/workflows/deploy_to_ghcr.yml
@@ -13,11 +13,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
-      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
-      POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -46,9 +41,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME || 'osaa-mvp' }}
-        POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB || 'postgres' }}
         USERNAME: ${{ secrets.USERNAME || 'osaa-mvp-user' }}
-        POSTGRES_PORT: ${{ secrets.POSTGRES_PORT || '5432' }}
       run: |
         docker run --name osaa-mvp \
           -e TARGET=$TARGET \
@@ -59,11 +52,6 @@ jobs:
           -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
           -e S3_BUCKET_NAME=$S3_BUCKET_NAME \
           -e USERNAME=$USERNAME \
-          -e POSTGRES_HOST=$POSTGRES_HOST \
-          -e POSTGRES_PORT=$POSTGRES_PORT \
-          -e POSTGRES_USER=$POSTGRES_USER \
-          -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-          -e POSTGRES_DATABASE=$POSTGRES_DATABASE \
           osaa-mvp etl dev_github_deploy
       continue-on-error: true
 

--- a/.github/workflows/run_from_ghcr.yml
+++ b/.github/workflows/run_from_ghcr.yml
@@ -10,11 +10,6 @@ jobs:
   build-and-test-container:
     runs-on: ubuntu-latest
     env:
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
-      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
-      POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,9 +38,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME || 'osaa-mvp' }}
-        POSTGRES_DATABASE: ${{ secrets.POSTGRES_DB || 'postgres' }}
         USERNAME: ${{ secrets.USERNAME || 'osaa-mvp-user' }}
-        POSTGRES_PORT: ${{ secrets.POSTGRES_PORT || '5432' }}
       run: |
         docker run --name osaa-mvp \
           -e TARGET=$TARGET \
@@ -56,11 +49,6 @@ jobs:
           -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
           -e S3_BUCKET_NAME=$S3_BUCKET_NAME \
           -e USERNAME=$USERNAME \
-          -e POSTGRES_HOST=$POSTGRES_HOST \
-          -e POSTGRES_PORT=$POSTGRES_PORT \
-          -e POSTGRES_USER=$POSTGRES_USER \
-          -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-          -e POSTGRES_DATABASE=$POSTGRES_DATABASE \
           osaa-mvp transform_dry_run dev_github_ci
 
     - name: Check Container Status

--- a/.github/workflows/run_from_ghcr.yml
+++ b/.github/workflows/run_from_ghcr.yml
@@ -61,7 +61,7 @@ jobs:
           -e POSTGRES_USER=$POSTGRES_USER \
           -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
           -e POSTGRES_DATABASE=$POSTGRES_DATABASE \
-          osaa-mvp etl dev_github_ci
+          osaa-mvp transform_dry_run dev_github_ci
 
     - name: Check Container Status
       run: |

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ osaa-mvp/
 ├── scratchpad/                # Temporary space for working code or notes
 ├── sqlMesh/                   # SQLMesh configuration and models
 │   ├── models/                # SQLMesh model definitions
-│   └── osaa_mvp.db            # DuckDB database for SQLMesh transformations
+│   └── unosaa_data_pipeline.db            # DuckDB database for SQLMesh transformations
 ├── src/
 │   └── pipeline/             # Core pipeline code
 │       ├── ingest/           # Handles data ingestion from local raw csv to S3 parquet

--- a/README.md
+++ b/README.md
@@ -151,13 +151,6 @@ Note: After installing Docker Desktop, you'll need to start the application befo
 
    **Database Connection:**
    ```bash
-   # PostgreSQL database for tracking data transformations
-   POSTGRES_HOST=<host>               # Database server address
-   POSTGRES_PORT=5432                 # Database connection port
-   POSTGRES_USER=<user>              # Database login username
-   POSTGRES_PASSWORD=<password>       # Database login password
-   POSTGRES_DATABASE=<database>       # Name of the database to use
-
    # Pipeline state management
    GATEWAY=shared_state              # Controls where transformation state is stored
                                     # Options: shared_state (PostgreSQL), local (DuckDB)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-common-config: &common-config
     - S3_BUCKET_NAME=${S3_BUCKET_NAME}
     - TARGET=${TARGET}
     - USERNAME=${USERNAME}
-    - DB_PATH=/app/sqlMesh/osaa_mvp.db
+    - DB_PATH=/app/sqlMesh/unosaa_data_pipeline.db
 
 services:
   pipeline:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,10 @@ case "$1" in
   "etl")
     echo "Starting pipeline"
 
+    # Download DB from S3 (or create new if doesn't exist)
+    echo "Downloading DB from S3..."
+    uv run python -m pipeline.s3_sync.run download
+
     echo "Start ingestion"
     uv run python -m pipeline.ingest.run
     echo "End ingestion"
@@ -36,6 +40,11 @@ case "$1" in
     cd sqlMesh
     uv run sqlmesh --gateway "${GATEWAY:-local}" plan --auto-apply --include-unmodified --create-from prod --no-prompts "${TARGET:-dev}"
     echo "End sqlMesh"
+
+    # Upload updated DB back to S3
+    cd ..  # Return to root directory
+    echo "Uploading DB to S3..."
+    uv run python -m pipeline.s3_sync.run upload
     ;;
   "config_test")
     uv run python -m pipeline.config_test

--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -2,14 +2,14 @@ gateways:
   local:
     connection:
       type: duckdb
-      database: osaa_mvp.db
+      database: unosaa_data_pipeline.db
       # Configure DuckDB with httpfs extension for S3 access
       extensions: ['httpfs']
 
   shared_state:
     connection:
       type: duckdb
-      database: osaa_mvp.db
+      database: unosaa_data_pipeline.db
       extensions: ['httpfs']
     state_connection:
       type: postgres

--- a/sqlMesh/config.yaml
+++ b/sqlMesh/config.yaml
@@ -11,14 +11,6 @@ gateways:
       type: duckdb
       database: unosaa_data_pipeline.db
       extensions: ['httpfs']
-    state_connection:
-      type: postgres
-      host: {{ env_var ('POSTGRES_HOST') }}
-      port: {{ env_var ('POSTGRES_PORT') | int }}
-      user: {{ env_var ('POSTGRES_USER') }}
-      password: {{ env_var ('POSTGRES_PASSWORD') }}
-      database: {{ env_var ('POSTGRES_DATABASE') }}
-      pre_ping: True
 
 default_gateway: local
 

--- a/sqlMesh/constants.py
+++ b/sqlMesh/constants.py
@@ -15,4 +15,4 @@ import os
 SQLMESH_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # Use environment variable with fallback to local path
-DB_PATH = os.getenv("DB_PATH", os.path.join(SQLMESH_DIR, "osaa_mvp.db"))
+DB_PATH = os.getenv("DB_PATH", os.path.join(SQLMESH_DIR, "unosaa_data_pipeline.db"))

--- a/sqlMesh/macros/ibis_expressions.py
+++ b/sqlMesh/macros/ibis_expressions.py
@@ -8,7 +8,7 @@ def generate_ibis_table(
     table_name: str,
     schema_name: str,
     column_schema: dict,
-    catalog_name: str = "osaa_mvp",
+    catalog_name: str = "unosaa_data_pipeline",
 ):
     """
     This macro generates an ibis table expression based on the provided parameters.

--- a/sqlMesh/models/sources/opri/data_national.sql
+++ b/sqlMesh/models/sources/opri/data_national.sql
@@ -18,5 +18,3 @@ MODEL (
     read_parquet(
         @s3_read('edu/OPRI_DATA_NATIONAL')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/opri/label.sql
+++ b/sqlMesh/models/sources/opri/label.sql
@@ -14,5 +14,3 @@ MODEL (
     read_parquet(
         @s3_read('edu/OPRI_LABEL')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/opri/opri_indicators.py
+++ b/sqlMesh/models/sources/opri/opri_indicators.py
@@ -21,8 +21,7 @@ COLUMN_SCHEMA = {
     "sources.opri",
     is_sql=True,
     kind="FULL",
-    columns=COLUMN_SCHEMA,
-    post_statements=["@s3_write()"]
+    columns=COLUMN_SCHEMA
 )
 def entrypoint(evaluator: MacroEvaluator) -> str:
     source_folder_path = "opri"

--- a/sqlMesh/models/sources/sdg/data_national.sql
+++ b/sqlMesh/models/sources/sdg/data_national.sql
@@ -18,5 +18,3 @@ MODEL (
     read_parquet(
         @s3_read('edu/SDG_DATA_NATIONAL')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/sdg/label.sql
+++ b/sqlMesh/models/sources/sdg/label.sql
@@ -14,5 +14,3 @@ MODEL (
     read_parquet(
         @s3_read('edu/SDG_LABEL')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/sdg/sdg_indicators.py
+++ b/sqlMesh/models/sources/sdg/sdg_indicators.py
@@ -22,7 +22,6 @@ COLUMN_SCHEMA = {
     is_sql=True,
     kind="FULL",
     columns=COLUMN_SCHEMA,
-    post_statements=["@s3_write()"],
     description="""This model contains Sustainable Development Goals (SDG) data for all countries and indicators.""",
     column_descriptions={
         "indicator_id": "The unique identifier for the indicator",

--- a/sqlMesh/models/sources/wdi/csv.sql
+++ b/sqlMesh/models/sources/wdi/csv.sql
@@ -79,5 +79,3 @@ MODEL (
       read_parquet(
         @s3_read('wdi/WDICSV')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/wdi/series.sql
+++ b/sqlMesh/models/sources/wdi/series.sql
@@ -31,5 +31,3 @@ MODEL (
     read_parquet(
         @s3_read('wdi/WDISeries')
     );
-
-@s3_write();

--- a/sqlMesh/models/sources/wdi/wdi_country_averages.py
+++ b/sqlMesh/models/sources/wdi/wdi_country_averages.py
@@ -21,8 +21,7 @@ COLUMN_SCHEMA = {
     "sources.wdi_country_averages",
     is_sql=True,
     kind="FULL",
-    columns=COLUMN_SCHEMA,
-    post_statements=["@s3_write()"]
+    columns=COLUMN_SCHEMA
 )
 def entrypoint(evaluator: MacroEvaluator) -> str:
     wdi = generate_ibis_table(

--- a/sqlMesh/models/sources/wdi/wdi_indicators.py
+++ b/sqlMesh/models/sources/wdi/wdi_indicators.py
@@ -21,8 +21,7 @@ COLUMN_SCHEMA = {
     "sources.wdi",
     is_sql=True,
     kind="FULL",
-    columns=COLUMN_SCHEMA,
-    post_statements=["@s3_write()"]
+    columns=COLUMN_SCHEMA
 )
 def entrypoint(evaluator: MacroEvaluator) -> str:
     """Process WDI data and return the transformed Ibis table."""

--- a/src/pipeline/config.py
+++ b/src/pipeline/config.py
@@ -27,7 +27,7 @@ STAGING_DATA_DIR = os.path.join(DATALAKE_DIR, "staging")
 MASTER_DATA_DIR = os.path.join(STAGING_DATA_DIR, "master")
 
 # Allow both Docker and local environment DuckDB path
-DB_PATH = os.getenv("DB_PATH", os.path.join(ROOT_DIR, "sqlMesh", "osaa_mvp.db"))
+DB_PATH = os.getenv("DB_PATH", os.path.join(ROOT_DIR, "sqlMesh", "unosaa_data_pipeline.db"))
 
 # Environment configurations
 TARGET = os.getenv("TARGET", "dev").lower()

--- a/src/pipeline/s3_sync/__init__.py
+++ b/src/pipeline/s3_sync/__init__.py
@@ -1,0 +1,18 @@
+"""S3 sync package for SQLMesh database file management.
+
+This package handles synchronization of SQLMesh database files with S3,
+including downloading and uploading operations.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+def init_s3_sync_package() -> None:
+    """Initialize the s3_sync package and log package details."""
+    logger.info("🔄 Initializing OSAA MVP S3 Sync Package")
+    logger.info("   📦 Package responsible for SQLMesh DB file sync")
+    logger.info("   🔍 Ready to sync with S3")
+
+# Call initialization when the package is imported
+init_s3_sync_package()

--- a/src/pipeline/s3_sync/run.py
+++ b/src/pipeline/s3_sync/run.py
@@ -49,6 +49,11 @@ def sync_db_with_s3(operation: str, db_path: str, bucket_name: str, s3_key: str)
                     raise S3OperationError(f"Error checking S3 object: {str(e)}")
                     
         elif operation == "upload":
+            # Only allow uploads in prod/qa environments
+            if os.getenv('TARGET', '').lower() not in ['prod', 'qa']:
+                logger.warning("Upload operation restricted to prod/qa targets only")
+                return
+                
             logger.info("Uploading DB to S3...")
             if os.path.exists(db_path):
                 s3_client.upload_file(db_path, bucket_name, s3_key)

--- a/src/pipeline/s3_sync/run.py
+++ b/src/pipeline/s3_sync/run.py
@@ -1,0 +1,85 @@
+"""Module for handling S3 synchronization of SQLMesh database files.
+
+This module provides functionality to sync SQLMesh database files with S3,
+including downloading existing DBs and uploading updated ones.
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+from pipeline.exceptions import S3OperationError
+from pipeline.logging_config import create_logger
+from pipeline.config import S3_BUCKET_NAME
+
+logger = create_logger(__name__)
+
+def sync_db_with_s3(operation: str, db_path: str, bucket_name: str, s3_key: str) -> None:
+    """
+    Sync SQLMesh database with S3.
+
+    Args:
+        operation: Either "download" or "upload"
+        db_path: Local path to the SQLMesh database file
+        bucket_name: S3 bucket name
+        s3_key: Key (path) in S3 bucket
+
+    Raises:
+        S3OperationError: If S3 operations fail
+    """
+    try:
+        s3_client = boto3.client('s3')
+        
+        if operation == "download":
+            logger.info("Attempting to download DB from S3...")
+            try:
+                s3_client.head_object(Bucket=bucket_name, Key=s3_key)
+                # File exists, download it
+                os.makedirs(os.path.dirname(db_path), exist_ok=True)
+                s3_client.download_file(bucket_name, s3_key, db_path)
+                logger.info("Successfully downloaded existing DB from S3")
+            except ClientError as e:
+                if e.response['Error']['Code'] == '404':
+                    logger.info("No existing DB found in S3, skipping download...")
+                else:
+                    raise S3OperationError(f"Error checking S3 object: {str(e)}")
+                    
+        elif operation == "upload":
+            logger.info("Uploading DB to S3...")
+            if os.path.exists(db_path):
+                s3_client.upload_file(db_path, bucket_name, s3_key)
+                logger.info("Successfully uploaded DB to S3")
+            else:
+                logger.warning(f"Local DB file not found at {db_path}, skipping upload")
+                
+    except Exception as e:
+        error_msg = f"S3 {operation} operation failed: {str(e)}"
+        logger.error(error_msg)
+        raise S3OperationError(error_msg)
+
+def get_db_paths(db_filename: Optional[str] = "unosaa_data_pipeline.db") -> tuple[str, str]:
+    """
+    Get the local and S3 paths for the database file.
+    
+    Args:
+        db_filename: Name of the database file
+        
+    Returns:
+        Tuple of (local_path, s3_key)
+    """
+    local_path = f"sqlMesh/{db_filename}"
+    s3_key = db_filename
+    return local_path, s3_key
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in ["download", "upload"]:
+        print("Usage: python -m pipeline.s3_sync.run [download|upload]")
+        sys.exit(1)
+
+    operation = sys.argv[1]
+    local_path, s3_key = get_db_paths()
+    sync_db_with_s3(operation, local_path, S3_BUCKET_NAME, s3_key) 

--- a/system_architecture.md
+++ b/system_architecture.md
@@ -65,7 +65,7 @@ end
         end
     end
 
-    subgraph "S3 Bucket (osaa_mvp)"
+    subgraph "S3 Bucket (unosaa-data-pipeline)"
         direction LR
         subgraph PB[prod/]
             direction LR

--- a/system_architecture_v2.md
+++ b/system_architecture_v2.md
@@ -62,7 +62,7 @@ flowchart TB
 
 
     %% S3 Bucket Structure
-    subgraph "S3 Bucket (osaa_mvp)"
+    subgraph "S3 Bucket (unosaa-data-pipeline)"
         direction LR
         %% Datalake Folder
         subgraph DLK[datalake/]


### PR DESCRIPTION
This PR introduces a state-sharing mechanism using S3 to upload and synchronize the DuckDB .db file. This ensures consistent database state across pipeline runs.  Additionally, it renames the SQLMesh database to `unosaa_data_pipeline.db` for consistency across:
  - SQLMesh config files
  - Docker environment variables
  - Python configuration files
  - Documentation and diagrams

### S3 Sync Implementation
- Added new `pipeline.s3_sync` module for database download and upload from/to S3 if target == qa or prod
- Modified docker ETL pipeline to:
  - Download latest database state from S3 before processing
  - Upload updated state to S3 after completion
- Revert GHA job build-and-test-container to only perform dry-run (no upload of database) 


## Testing
The following scenarios were tested:
1. Running the pipeline from scratch without pre-existing remote and local database versions.
2. Running the pipeline with a downloaded initial database from S3.
3. Running the pipeline with pre-existing local and remote databases.

In all cases, the SQLMesh pipeline successfully handled the database state, with the new module downloading, uploading and skipping as expected.


## Cleanup

1. Deprecated configs related to POSTGRES State management
2. Removed file-based s3 upload for intermediate steps

## Next Steps
1. Restructure ingestion step for decoupling of tasks (introducing new datasets - ingestions) (read from pre-existing datasets is already baked into initial source models in SQLMesh)
2. Ensure bucket `unosaa-data-pipeline` has versioning enabled for disaster recovery
3. Improve AWS Setup to ensure only service account used by GHA can modify the db file and avoid accidental overwrite by users. Currently, the only control is the target env_var, and even though users should strictly use TARGET=dev, there is a chance that someone inadvertently uses `qa` or `prod` targets thus causing an undesired file overwrite
