### PR TITLE
A metadata model added

### DIFF
--- a/sqlMesh/models/_metadata/all_models.py
+++ b/sqlMesh/models/_metadata/all_models.py
@@ -1,0 +1,63 @@
+import ibis
+from sqlmesh.core.macros import MacroEvaluator
+from sqlmesh.core.model import model
+from constants import DB_PATH
+import os
+
+os.environ["PYTHONWARNINGS"] = "ignore"
+
+COLUMN_SCHEMA = {
+    "model_name": "String",
+    "model_description": "String",
+    "model_kind": "String",
+    "grain": "String",
+    "columns": "String",
+    "column_descriptions": "String",
+    "physical_properties": "String",
+}
+
+
+@model(
+    "_metadata.all_models",
+    is_sql=True,
+    kind="FULL",
+    depends_on=["master.indicators"],
+    columns=COLUMN_SCHEMA,
+    post_statements=["@s3_write()"],
+)
+def entrypoint(evaluator: MacroEvaluator) -> str:
+    """
+    This model is used to get the model properties of the latest snapshot.
+    The user may see the following warning the first time they run the project, but they can safely ignore it: 
+    ```
+    2025-01-21 20:39:23,269 - MainThread - sqlmesh.core.renderer - WARNING - SELECT * cannot be expanded due to missing schema(s) for model(s): '"unbound_table_1"'. 
+    Run `sqlmesh create_external_models` and / or make sure that the model '"osaa_mvp"."_metadata"."all_models"' can be rendered at parse time. (renderer.py:540)
+    ```
+    """
+    con = ibis.connect(f"duckdb://{DB_PATH}")
+
+    try:
+        query = """
+            SELECT
+                json_extract(s.snapshot, '$.node.name') AS model_name,
+                json_extract(s.snapshot, '$.node.description') AS model_description,
+                json_extract(s.snapshot, '$.node.kind') AS model_kind,
+                json_extract(s.snapshot, '$.node.grains') AS grain,
+                json_extract(s.snapshot, '$.node.columns') AS columns,
+                json_extract(s.snapshot, '$.node.column_descriptions') AS column_descriptions,
+                json_extract(s.snapshot, '$.node.physical_properties') AS physical_properties
+            FROM 
+                sqlmesh._snapshots s
+            INNER JOIN (
+                SELECT name, MAX(updated_ts) AS max_updated_ts
+                FROM sqlmesh._snapshots
+                GROUP BY name
+            ) latest ON s.name = latest.name AND s.updated_ts = latest.max_updated_ts
+            ;
+        """
+
+        t = con.sql(query)
+    except Exception:
+        t = ibis.table(schema=COLUMN_SCHEMA)
+
+    return ibis.to_sql(t)

--- a/sqlMesh/models/_metadata/all_models.py
+++ b/sqlMesh/models/_metadata/all_models.py
@@ -2,9 +2,7 @@ import ibis
 from sqlmesh.core.macros import MacroEvaluator
 from sqlmesh.core.model import model
 from constants import DB_PATH
-import os
 
-os.environ["PYTHONWARNINGS"] = "ignore"
 
 COLUMN_SCHEMA = {
     "model_name": "String",
@@ -28,9 +26,9 @@ COLUMN_SCHEMA = {
 def entrypoint(evaluator: MacroEvaluator) -> str:
     """
     This model is used to get the model properties of the latest snapshot.
-    The user may see the following warning the first time they run the project, but they can safely ignore it: 
+    The user may see the following warning the first time they run the project, but they can safely ignore it:
     ```
-    2025-01-21 20:39:23,269 - MainThread - sqlmesh.core.renderer - WARNING - SELECT * cannot be expanded due to missing schema(s) for model(s): '"unbound_table_1"'. 
+    2025-01-21 20:39:23,269 - MainThread - sqlmesh.core.renderer - WARNING - SELECT * cannot be expanded due to missing schema(s) for model(s): '"unbound_table_1"'.
     Run `sqlmesh create_external_models` and / or make sure that the model '"osaa_mvp"."_metadata"."all_models"' can be rendered at parse time. (renderer.py:540)
     ```
     """


### PR DESCRIPTION
## Changes
- Added the `all_models` model that returns a table with columns like model_name, column_descriptions, grain, etc, under `_metadata` schema/folder (we can change it)

## How to test
- Run `docker compose run --rm pipeline transform`
- Run a series of commands to test the first project run: 
    - `docker image rm osaa-mvp-pipeline`
    - `docker build prune`
    - `rm -r sqlmesh/.cache sqlmesh/osaa_mvp.db sqlmesh/__pycache__ sqlmesh/*/*/__pycache__`  # remove db/cache in the project
    - `docker compose run --rm pipeline transform`

## Note
- One caveat is that we need to run this model last, that requires you to input all the leaf nodes of the pipeline in the `depends_on` model property. [There doesn't seem to be a way to use a wildcard as an input like this `depends_on=["sources.*"]`](https://tobiko-data.slack.com/archives/C07HJH22U9Z/p1737475016134629)